### PR TITLE
fix: Add subnet group dependency on IAM resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -109,6 +109,12 @@ resource "aws_dms_replication_subnet_group" "this" {
   subnet_ids                           = var.repl_subnet_group_subnet_ids
 
   tags = merge(var.tags, var.repl_subnet_group_tags)
+
+  depends_on = [
+    aws_iam_role.dms_access_for_endpoint,
+    aws_iam_role.dms_cloudwatch_logs_role,
+    aws_iam_role.dms_vpc_role,
+  ]
 }
 
 ################################################################################

--- a/main.tf
+++ b/main.tf
@@ -111,9 +111,7 @@ resource "aws_dms_replication_subnet_group" "this" {
   tags = merge(var.tags, var.repl_subnet_group_tags)
 
   depends_on = [
-    aws_iam_role.dms_access_for_endpoint,
-    aws_iam_role.dms_cloudwatch_logs_role,
-    aws_iam_role.dms_vpc_role,
+    aws_iam_role.dms_vpc_role
   ]
 }
 


### PR DESCRIPTION
## Description
As explained in the linked issue, there is a race condition when creating the subnet group before the IAM resources have been created.

## Motivation and Context
Fixes #6

## How Has This Been Tested?
Observed the following failure occurring on an initial run of the module:

```
Error: AccessDeniedFault: The IAM Role arn:aws:iam::REDACTED:role/dms-vpc-role is not configured properly.

with module.dms[0].aws_dms_replication_subnet_group.this[0]
on .terraform/modules/dms/main.tf line 89, in resource "aws_dms_replication_subnet_group" "this":
resource "aws_dms_replication_subnet_group" "this" {
``` 

Made this change in a fork of this module, observed the failure no longer occurring. However, I did not test (because I was not able to) deleting this IAM role and re-running.

## Screenshots (if appropriate):
