### PR TITLE
feat: Allow for passwords to be in secrets manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ No modules.
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_secretsmanager_secret.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
- 
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |

--- a/README.md
+++ b/README.md
@@ -332,7 +332,9 @@ No modules.
 | [aws_iam_policy_document.dms_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.dms_assume_role_redshift](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
-
+| [aws_secretsmanager_secret.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
+| [aws_secretsmanager_secret_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
+ 
 ## Inputs
 
 | Name | Description | Type | Default | Required |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -421,6 +421,19 @@ module "dms_aurora_postgresql_aurora_mysql" {
       ssl_mode                    = "none"
       tags                        = { EndpointType = "mysql-destination" }
     }
+
+    mssql-destination = {
+      database_name        = local.db_name
+      endpoint_id          = "${local.name}-mssql-destination"
+      endpoint_type        = "target"
+      engine_name          = "sqlserver"
+      username             = local.db_username
+      password_secret_path = "path/to/secret/manager/secret"
+      port                 = 1433
+      server_name          = "existing-db.address.us-east-1.rds.amazonaws.com"
+      ssl_mode             = "require"
+      tags                 = { EndpointType = "mssql-destination" }
+    }
   }
 
   replication_tasks = {


### PR DESCRIPTION
## Description
I used this module to setup DMS using existing database instances, but did not want to store plaintext credentials in git (for obvious reasons). These details were in Secrets Manager, so I added a new `endpoint` config entry `password_secret_path` that takes a Secret Manager path. When this entry is non-null, the module will read that path for the password value.

This expects the secret value to be a plaintext secret type.

When `password_secret_path` is set `secret` is ignored.

## Motivation and Context
To allow the use of existing instances whose authentication details are in Secret Manager.

## How Has This Been Tested?
Used to deploy DMS to replicate between two MSSQL instances.

## Screenshots (if appropriate):
