### PR TITLE
fix: declare endpoints output as sensitive

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -84,6 +84,7 @@ output "replication_tasks" {
 output "endpoints" {
   description = "A map of maps containing the endpoints created and their full output of attributes and values"
   value       = aws_dms_endpoint.this
+  sensitive   = true
 }
 
 # Event Subscriptions


### PR DESCRIPTION
## Description
In Terraform version 0.14 and above, module outputs with sensitive keys need to be marked as sensitive. Currently, this module will error out with this message:

```╷
│ Error: Output refers to sensitive values
│
│   on outputs.tf line 84:
│   84: output "endpoints" {
│
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true
╵
```

## Motivation and Context
Allows apply to complete on Terraform 0.14 and above. 

## How Has This Been Tested?
Initially observed a Terraform  apply fail with the above error message. Once this change was made, the apply was allowed to complete.

## Screenshots (if appropriate):
