### PR TITLE
feat: Add support for DMS replication task `start_replication_task`

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,13 +318,13 @@ Security scanning results provided by Bridgecrew. Bridgecrew is the leading full
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.6 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.6 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -30,14 +30,14 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.6 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.6 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.2"
+      version = ">= 4.6"
     }
     random = {
       source  = "hashicorp/random"

--- a/main.tf
+++ b/main.tf
@@ -302,6 +302,7 @@ resource "aws_dms_replication_task" "this" {
   table_mappings            = lookup(each.value, "table_mappings", null)
   source_endpoint_arn       = aws_dms_endpoint.this[each.value.source_endpoint_key].endpoint_arn
   target_endpoint_arn       = aws_dms_endpoint.this[each.value.target_endpoint_key].endpoint_arn
+  start_replication_task    = lookup(each.value, "start_replication_task", null)
 
   tags = merge(var.tags, lookup(each.value, "tags", {}))
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.2"
+      version = ">= 4.6"
     }
   }
 }


### PR DESCRIPTION
## Description
- Add support for DMS replication task `start_replication_task`
- Bump AWS provider min supported version to v4.6.0 to support `start_replication_task`

## Motivation and Context
- Closes #4

## How Has This Been Tested?
- `examples/complete`

## Screenshots (if appropriate):
