### PR TITLE
feat: Support DMS Endpoint Postgres Settings about IAM authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,14 +304,14 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.96 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.5 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.96 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.5 |
 | <a name="provider_time"></a> [time](#provider\_time) | >= 0.9 |
 
 ## Modules

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -28,13 +28,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.96 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.5 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.96 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.5 |
 
 ## Modules
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.96"
+      version = ">= 6.5"
     }
   }
 }

--- a/examples/serverless/README.md
+++ b/examples/serverless/README.md
@@ -26,13 +26,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.96 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.5 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.96 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.5 |
 
 ## Modules
 

--- a/examples/serverless/versions.tf
+++ b/examples/serverless/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.96"
+      version = ">= 6.5"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -281,6 +281,7 @@ resource "aws_dms_endpoint" "this" {
       map_long_varchar_as          = try(postgres_settings.value.map_long_varchar_as, null)
       max_file_size                = try(postgres_settings.value.max_file_size, null)
       plugin_name                  = try(postgres_settings.value.plugin_name, null)
+      service_access_role_arn      = try(postgres_settings.value.service_access_role_arn, null)
       slot_name                    = try(postgres_settings.value.slot_name, null)
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -266,6 +266,7 @@ resource "aws_dms_endpoint" "this" {
     for_each = length(lookup(each.value, "postgres_settings", [])) > 0 ? [each.value.postgres_settings] : []
     content {
       after_connect_script         = try(postgres_settings.value.after_connect_script, null)
+      authentication_method        = try(postgres_settings.value.authentication_method, null)
       babelfish_database_name      = try(postgres_settings.value.babelfish_database_name, null)
       capture_ddls                 = try(postgres_settings.value.capture_ddls, null)
       database_mode                = try(postgres_settings.value.database_mode, null)

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ locals {
   account_id = data.aws_caller_identity.current.account_id
   dns_suffix = data.aws_partition.current.dns_suffix
   partition  = data.aws_partition.current.partition
-  region     = data.aws_region.current.name
+  region     = data.aws_region.current.region
 
   subnet_group_id = var.create && var.create_repl_subnet_group ? aws_dms_replication_subnet_group.this[0].id : var.repl_instance_subnet_group_id
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.96"
+      version = ">= 6.5"
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
## Description

Support `authentication_method` and `service_access_role_arn` for DMS endpoint postgres settings.
The setting was supported from 6.5 for IAM authentication.

- https://github.com/hashicorp/terraform-provider-aws/pull/43440
- https://registry.terraform.io/providers/hashicorp/aws/6.5.0/docs/resources/dms_endpoint

## Motivation and Context

I am trying to set up a DMS module with IAM-authenticated postgres source endpoint.

## Breaking Changes

No.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
