### PR TITLE
fix: Subscriptions source id conditions updated to handle array for instances and not base the key of subscription on the name of the task.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -459,11 +459,11 @@ resource "aws_dms_event_subscription" "this" {
   source_ids = compact(concat(
     [
       for instance in aws_dms_replication_instance.this[*] :
-      instance.replication_instance_id if lookup(each.value, "instance_event_subscription_keys", null) == var.repl_instance_id
+      instance.replication_instance_id if contains(lookup(each.value, "instance_event_subscription_keys", []), var.repl_instance_id)
     ],
     [
       for task in aws_dms_replication_task.this[*] :
-      task.replication_task_id if contains(lookup(each.value, "task_event_subscription_keys", []), each.key)
+      task.replication_task_id if contains(lookup(each.value, "task_event_subscription_keys", []), task.replication_task_id)
     ]
   ))
 


### PR DESCRIPTION
## Description

Documentation suggests `instance_event_subscription_keys` needs to be an array and the use of `each.key` for selecting tasks is confusing. Updating conditions for subscriptions to source from the correct ids.

## Motivation and Context

Tasks required a small hack to work around but doesn't follow documentation.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
