### PR TITLE
feat: Optionally create tasks and instances separately.

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ No modules.
 | <a name="input_repl_subnet_group_name"></a> [repl\_subnet\_group\_name](#input\_repl\_subnet\_group\_name) | The name for the replication subnet group. Stored as a lowercase string, must contain no more than 255 alphanumeric characters, periods, spaces, underscores, or hyphens | `string` | `null` | no |
 | <a name="input_repl_subnet_group_subnet_ids"></a> [repl\_subnet\_group\_subnet\_ids](#input\_repl\_subnet\_group\_subnet\_ids) | A list of the EC2 subnet IDs for the subnet group | `list(string)` | `[]` | no |
 | <a name="input_repl_subnet_group_tags"></a> [repl\_subnet\_group\_tags](#input\_repl\_subnet\_group\_tags) | A map of additional tags to apply to the replication subnet group | `map(string)` | `{}` | no |
+| <a name="input_replication_instance_arn"></a> [replication\_instance\_arn](#input\_replication\_instance\_arn) | The ARN of an existing replication instance to be used by replication tasks. Required if `create_repl_instance` is set to `false` | `string` | `null` | no |
 | <a name="input_replication_tasks"></a> [replication\_tasks](#input\_replication\_tasks) | Map of objects that define the replication tasks to be created | `any` | `{}` | no |
 | <a name="input_s3_endpoints"></a> [s3\_endpoints](#input\_s3\_endpoints) | Map of objects that define the S3 endpoints to be created | `any` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to use on all resources | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ locals {
   account_id = data.aws_caller_identity.current.account_id
   dns_suffix = data.aws_partition.current.dns_suffix
   partition  = data.aws_partition.current.partition
-  region     = data.aws_region.current.name
+  region     = data.aws_region.current.id
 
   subnet_group_id = var.create && var.create_repl_subnet_group ? aws_dms_replication_subnet_group.this[0].id : var.repl_instance_subnet_group_id
 }

--- a/main.tf
+++ b/main.tf
@@ -391,7 +391,7 @@ resource "aws_dms_replication_task" "this" {
   cdc_start_position        = try(each.value.cdc_start_position, null)
   cdc_start_time            = try(each.value.cdc_start_time, null)
   migration_type            = each.value.migration_type
-  replication_instance_arn  = aws_dms_replication_instance.this[0].replication_instance_arn
+  replication_instance_arn  = var.create_repl_instance ? aws_dms_replication_instance.this[0].replication_instance_arn : try(var.replication_instance_arn, null)
   replication_task_id       = each.value.replication_task_id
   replication_task_settings = try(each.value.replication_task_settings, null)
   resource_identifier       = try(each.value.resource_identifier, null)

--- a/outputs.tf
+++ b/outputs.tf
@@ -65,7 +65,7 @@ output "replication_subnet_group_id" {
 
 output "replication_instance_arn" {
   description = "The Amazon Resource Name (ARN) of the replication instance"
-  value       = try(aws_dms_replication_instance.this[0].replication_instance_arn, null)
+  value       = try(aws_dms_replication_instance.this[0].replication_instance_arn, var.replication_instance_arn)
 }
 
 output "replication_instance_private_ips" {

--- a/variables.tf
+++ b/variables.tf
@@ -84,6 +84,12 @@ variable "create_repl_instance" {
   default     = true
 }
 
+variable "replication_instance_arn" {
+  description = "The ARN of an existing replication instance to be used by replication tasks. Required if `create_repl_instance` is set to `false`"
+  type        = string
+  default     = null
+}
+
 variable "repl_instance_allocated_storage" {
   description = "The amount of storage (in gigabytes) to be initially allocated for the replication instance. Min: 5, Max: 6144, Default: 50"
   type        = number


### PR DESCRIPTION
## Description

Allow tasks creation to be made separate from the instances

## Motivation and Context

While DMS tasks are dependent on instances, these resources may have different levels of volitility in an organization. This will allow orgs to separate instance/compute (i.e. platform) from state/event (i.e. application data) requirements.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
